### PR TITLE
Poprawiona definicja struktury Buyer

### DIFF
--- a/KSeF.Client/Core/Models/Invoices/Buyer.cs
+++ b/KSeF.Client/Core/Models/Invoices/Buyer.cs
@@ -3,6 +3,6 @@ namespace KSeF.Client.Core.Models.Invoices;
 
 public class Buyer
 {
-    public BuyerIdentifier Identifier { get; set; }
+    public Identifier Identifier { get; set; }
     public string Name { get; set; }
 }

--- a/KSeF.Client/Core/Models/Invoices/Identifier.cs
+++ b/KSeF.Client/Core/Models/Invoices/Identifier.cs
@@ -1,7 +1,7 @@
 
 namespace KSeF.Client.Core.Models.Invoices;
 
-public class BuyerIdentifier
+public class Identifier
 {
     public IdentifierType Type { get; set; }
     public string Value { get; set; }

--- a/KSeF.Client/Core/Models/Invoices/ThirdSubjects.cs
+++ b/KSeF.Client/Core/Models/Invoices/ThirdSubjects.cs
@@ -3,8 +3,7 @@ namespace KSeF.Client.Core.Models.Invoices;
 
 public class ThirdSubjects
 {
-    public IdentifierType IdentifierType { get; set; } 
-    public string Identifier { get; set; }
+    public Identifier Identifier { get; set; }
     public string Name { get; set; }
     public int Role { get; set; }
 }


### PR DESCRIPTION
Struktura `Buyer` w kolekcji metadanych faktur zwracanych przez `QueryInvoiceMetadata` wydaje się być niezgodna z [ze specyfikacją](https://ksef-test.mf.gov.pl/docs/v2/index.html#tag/Pobieranie-faktur/paths/~1api~1v2~1invoices~1query~1metadata/post) i z danymi zwracanymi przez środowisko testowe.

Dotychczasowa definicja struktury oczekuje danych w postaci:
```
"buyer": {
    "identifierType": "Nip",
    "identifier": "7352765225"
    "name": "Test Company 4"
}
```

podczas gdy w przykładzie i w środowisku testowym występuje:

```
"buyer": {
    "identifier": 
    {
        "type": "Nip",
        "value": "7352765225"
    },
    "name": "Test Company 4"
}
```