### PR TITLE
Kompilacja dla .NET 8 i .NET 9 (#22)

### DIFF
--- a/KSeF.Client/Api/Services/VerificationLinkService .cs
+++ b/KSeF.Client/Api/Services/VerificationLinkService .cs
@@ -21,7 +21,7 @@ namespace KSeF.Client.Api.Services
         {
             var date = issueDate.ToString("dd-MM-yyyy");
             var bytes = Convert.FromBase64String(invoiceHash);
-            var urlEncoded = Base64Url.EncodeToString(bytes);
+            var urlEncoded = Base64Url_EncodeToString(bytes);
             return $"{BaseUrl}/invoice/{nip}/{date}/{urlEncoded}";
         }
 
@@ -36,7 +36,7 @@ namespace KSeF.Client.Api.Services
         )
         {            
             var bytes = Convert.FromBase64String(invoiceHash);
-            var invoiceHashUrlEncoded = Base64Url.EncodeToString(bytes);
+            var invoiceHashUrlEncoded = Base64Url_EncodeToString(bytes);
 
             var pathToSign = $"{BaseUrl}/certificate/{contextIdentifierType}/{contextIdentifierValue}/{sellerNip}/{certificateSerial}/{invoiceHashUrlEncoded}".Replace("https://", "");
             var signedHash = ComputeUrlEncodedSignedHash(pathToSign, signingCertificate, privateKey);
@@ -105,7 +105,16 @@ namespace KSeF.Client.Api.Services
             }
 
             // 3. Base64 + URL-encode            
-            return Base64Url.EncodeToString(signature);            
+            return Base64Url_EncodeToString(signature);            
         }
-    }
+
+		private static string Base64Url_EncodeToString(byte[] blob)
+		{
+#if NET8_0
+			return Convert.ToBase64String(blob).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+#else
+			return Base64Url.EncodeToString(blob);
+#endif
+		}
+	}
 }

--- a/KSeF.Client/KSeF.Client.csproj
+++ b/KSeF.Client/KSeF.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>true</IsPackable>
 		<PackageId>KSeF2.0</PackageId>


### PR DESCRIPTION
Ta zmiana daje możliwość korzystania z biblioteki z poziomu aplikacji korzystających z .NET 8.

Mimo że w komentarzach do zgłoszenia #22 wskazano, że wsparcie dla .NET 8 nie jest przewidziane, wnioskuję o ponowne rozważenie tej decyzji. Różnice w kodzie pomiędzy wersją .NET 8 a .NET 9 są niewielkie i sprowadzają się do braku gotowej metody `Base64Url.EncodeToString`, której własna implementacja jest trywialna.