### PR TITLE
Kwoty netto, brutto i VAT jako liczy dziesiętne (decimal) zamiast double

### DIFF
--- a/KSeF.Client/Core/Models/Invoices/InvoiceSummary.cs
+++ b/KSeF.Client/Core/Models/Invoices/InvoiceSummary.cs
@@ -48,17 +48,17 @@ public class InvoiceSummary
     /// <summary>
     /// Łączna kwota netto.
     /// </summary>
-    public double NetAmount { get; set; }
+    public decimal NetAmount { get; set; }
 
     /// <summary>
     /// Łączna kwota brutto.
     /// </summary>
-    public double GrossAmount { get; set; }
+    public decimal GrossAmount { get; set; }
 
     /// <summary>
     /// Łączna kwota VAT.
     /// </summary>
-    public double VatAmount { get; set; }
+    public decimal VatAmount { get; set; }
 
     /// <summary>
     /// Kod waluty.


### PR DESCRIPTION
Obecnie kwoty netto, brutto i VAT zwracane są jako binarne liczby zmiennoprzecinkowe (`double`) mające precyzję do 16 cyfr dziesiętnych, co może prowadzić do przekłamań przy fakturach na kwoty powyżej 10 bilionów.

Zmiana typu z `double` na `decimal` ma na celu:
 * zachowanie spójności z kwotami przekazywanymi w polach `InvoiceMetadata.TotalAmountDue` i `AmountFilter.To` / `From`
 * zachowanie groszowej precyzji przy kwotach do 100 kwadrylionów