### PR TITLE
Fix TestDataClient rate limit method and cleanup whitespace

### DIFF
--- a/KSeF.Client/Clients/TestDataClient.cs
+++ b/KSeF.Client/Clients/TestDataClient.cs
@@ -72,12 +72,12 @@ namespace KSeF.Client.Clients
              ExecuteAsync<Status>(Routes.TestData.ProductionRateLimits, HttpMethod.Post, accessToken, cancellationToken);
 
         /// <inheritdoc />
-        public Task<Status> UnblockContextAsync(ContextIdentifier requestPayload, string accessToken, CancellationToken cancellationToken = default) =>  
+        public Task<Status> UnblockContextAsync(ContextIdentifier requestPayload, string accessToken, CancellationToken cancellationToken = default) =>
             ExecuteAsync<Status, ContextIdentifier>(Routes.TestData.UnblockContext, requestPayload, accessToken, cancellationToken);
 
         /// <inheritdoc />
-        public Task<Status> BlockContextAsync(ContextIdentifier requestPayload, string accessToken, CancellationToken cancellationToken = default) =>            
-            ExecuteAsync<Status, ContextIdentifier>(Routes.TestData.BlockContext, requestPayload, accessToken, cancellationToken);        
+        public Task<Status> BlockContextAsync(ContextIdentifier requestPayload, string accessToken, CancellationToken cancellationToken = default) =>
+            ExecuteAsync<Status, ContextIdentifier>(Routes.TestData.BlockContext, requestPayload, accessToken, cancellationToken);
 
     }
 }

--- a/KSeF.Client/Clients/TestDataClient.cs
+++ b/KSeF.Client/Clients/TestDataClient.cs
@@ -69,7 +69,7 @@ namespace KSeF.Client.Clients
 
         /// <inheritdoc />
         public Task<Status> RestoreProductionRateLimitsAsync(string accessToken, CancellationToken cancellationToken = default) =>
-             ExecuteAsync<Status>(Routes.TestData.RestoreDefaultCertificatesLimitInCurrentSubject, HttpMethod.Delete, accessToken, cancellationToken);
+             ExecuteAsync<Status>(Routes.TestData.ProductionRateLimits, HttpMethod.Post, accessToken, cancellationToken);
 
         /// <inheritdoc />
         public Task<Status> UnblockContextAsync(ContextIdentifier requestPayload, string accessToken, CancellationToken cancellationToken = default) =>  


### PR DESCRIPTION
This pull request updates the `RestoreProductionRateLimitsAsync` method in `TestDataClient` to use the correct API route and HTTP method for restoring production rate limits.

**API integration fix:**

* Updated `RestoreProductionRateLimitsAsync` to call `Routes.TestData.ProductionRateLimits` with `HttpMethod.Post` instead of the previous route and method, ensuring the method aligns with the intended API endpoint.

Fixes #216 